### PR TITLE
Use ctest framework along with gtest

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,6 +31,5 @@ jobs:
           run: cmake --build --preset ${{ env.PRESET }}
 
         - name: Run unit tests
-          working-directory: ./out/build/linux-debug/bin
-          run: ./run-tests
+          run: ctest --preset ${{ env.PRESET }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,5 @@ jobs:
           run: cmake --build --preset ${{ env.PRESET }}
 
         - name: Run unit tests
-          working-directory: ./out/build/linux-debug/bin
-          run: ./run-tests
+          run: ctest --preset ${{ env.PRESET }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required(VERSION 3.23)
 
 project("sfml-sorting")
+include(CTest)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,5 +29,17 @@
             "name": "linux-debug",
             "configurePreset": "linux-debug"
         }
+    ],
+    "testPresets":
+    [
+        {
+            "name": "linux-debug",
+            "configurePreset": "linux-debug",
+            "output": {"verbosity": "verbose"},
+            "environment":
+            {
+                "GTEST_COLOR": "1"
+            }
+        }
     ]
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,17 +2,18 @@
 
 include(FetchContent)
 FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/cb455a71fb23303e37ce8ee5b1cde6a2c18f66a5.zip
+    googletest
+    URL https://github.com/google/googletest/archive/cb455a71fb23303e37ce8ee5b1cde6a2c18f66a5.zip
 )
 
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
-add_executable(run-tests RandomNumberGeneratorTests.cpp)
+if(BUILD_TESTING)
+    add_executable(ctest-run-tests RandomNumberGeneratorTests.cpp)
+    target_link_libraries(ctest-run-tests PRIVATE GTest::gtest_main utils)
 
-target_link_libraries(run-tests GTest::gtest_main utils)
-
-include(GoogleTest)
-gtest_discover_tests(run-tests)
+    include(GoogleTest)
+    gtest_discover_tests(ctest-run-tests)
+endif()


### PR DESCRIPTION
Use ctest framework with gtest instead of running executable.

Update actions to accomodate testing changes.

closes #19