### PR TITLE
Fix random number range calculation

### DIFF
--- a/src/utils/RandomNumberGenerator.cpp
+++ b/src/utils/RandomNumberGenerator.cpp
@@ -22,6 +22,6 @@ int RandomNumberGenerator::GetMin() const
 
 int RandomNumberGenerator::GenerateRandomNumber() const
 {
-    auto numberGenerated = ((rand() % max) + min);
-    return static_cast<int>(numberGenerated);
+    auto numberGenerated = rand() % (max - min + 1) + min;
+    return numberGenerated;
 }


### PR DESCRIPTION
Description
This pull request addresses an issue with the random number generation formula used in the project. The previous implementation was not correctly calculating the range of generated numbers, which could lead to unintended results.

Problem:
auto numberGenerated = (rand() % max) + min;

had issues:

- The resulting range was incorrect, especially when min was not zero.
- The formula could generate numbers outside the desired [min, max] range.

Solution:
auto numberGenerated = (rand() % (max - min + 1)) + min;

I have tested the updated formula with various ranges, including negative values, to ensure that it behaves as expected.

Please review the changes and let me know if there are any further adjustments required. Thank you!